### PR TITLE
Update telepathy-mission-control-5.16.3-r1.ebuild

### DIFF
--- a/net-im/telepathy-mission-control/telepathy-mission-control-5.16.3-r1.ebuild
+++ b/net-im/telepathy-mission-control/telepathy-mission-control-5.16.3-r1.ebuild
@@ -62,5 +62,6 @@ src_configure() {
 		 --disable-static \
 		$(use_enable debug) \
 		$(use_enable deprecated) \
+		$(use_enable deprecated upower) \
 		$(use_with networkmanager connectivity nm)
 }


### PR DESCRIPTION
net-im/telepathy-mission-control fails to build with USE='-deprecated'
